### PR TITLE
terraform: update replacement logic for CF updates

### DIFF
--- a/terraform/module-external-worker/worker.tf
+++ b/terraform/module-external-worker/worker.tf
@@ -144,7 +144,7 @@ resource "aws_cloudformation_stack" "worker" {
       },
       "UpdatePolicy": {
         "AutoScalingRollingUpdate": {
-          "MinInstancesInService": "1",
+          "MinInstancesInService": "${var.worker_asg_min_size == 1 ? 0 : 1}",
           "MinSuccessfulInstancesPercent": "50",
           "SuspendProcesses": ["ScheduledActions"],
           "MaxBatchSize": "2",


### PR DESCRIPTION
The update of CF couldn't work when having only 1 worker, with a minimum
instance size in service of 1. So if the minimum worker count is 1, this
number is set to 0, or 1 otherwise.