### PR TITLE
ansible: Let the concourse-worker systemd service use only 90% of the…

### DIFF
--- a/ansible/external-worker.yml
+++ b/ansible/external-worker.yml
@@ -103,6 +103,17 @@
       tags:
        - notforbuild
 
+    - role: cycloid.systemd
+      systemd_type: dropin
+      systemd_dropin_service_name: "concourse-worker"
+      systemd_dropin_name: memorylimit
+      systemd_dropin_priority: "02"
+      systemd_dropin_content:
+        - "[Service]"
+        - "MemoryLimit={{ (ansible_memtotal_mb * 0.9) | int | abs }}M"
+      tags:
+        - notforbuild
+
     - role: cycloid.concourse
       tags:
         - concourse


### PR DESCRIPTION
… machine memory

Moved from the playbook to the stack as the playbook is often run during
the packer build, which led to a bad memory limit.

Linked to: https://github.com/cycloidio/ansible-concourse/pull/4