### PR TITLE
extra: implement flexible engine external worker script based on HEAT

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,6 @@ https://eu-central-1.console.aws.amazon.com/cloudformation/home?region=eu-west-1
 &param_TeamId=...
 ```
 
-> Internal note to refresh the file on s3 : `aws s3 cp extra/aws/external-worker-aws-cf-template.yaml s3://cycloid-cloudformation/`
-
-
 
 # Troubleshooting
 

--- a/extra/README.md
+++ b/extra/README.md
@@ -1,0 +1,17 @@
+# Cycloid notes
+
+# Update exteral workers stack templates
+
+```bash
+export AWS_ACCESS_KEY_ID=$(vault read -field=access_key secret/$CUSTOMER/aws)
+export AWS_SECRET_ACCESS_KEY=$(vault read -field=secret_key secret/$CUSTOMER/aws)
+
+# AWS
+aws s3 cp aws/external-worker-aws-cf-template.yaml s3://cycloid-cloudformation/
+
+# Flexible engine
+cd flexible-engine && zip -r /tmp/flexible-engine.zip Resources/ main.yaml && cd -
+aws s3 cp /tmp/flexible-engine.zip s3://cycloid-cloudformation/
+```
+
+

--- a/extra/flexible-engine/Resources/HotFiles/flexible-engine-worker.yaml
+++ b/extra/flexible-engine/Resources/HotFiles/flexible-engine-worker.yaml
@@ -1,0 +1,129 @@
+heat_template_version: 2014-10-16
+description: Create Cycloid workers
+parameters:
+  project_tag:
+    type: string
+  customer_tag:
+    type: string
+  flavor:
+    type: string
+  image_id:
+    type: string
+  key_name:
+    type: string
+  system_disk_size:
+    type: number
+  worker_disk_size:
+    type: number
+  network_id:
+    type: string
+  security_group_id:
+    type: string
+  scheduler_api_address:
+    type: string
+  scheduler_host:
+    type: string
+  scheduler_port:
+    type: string
+  tsa_public_key:
+    type: string
+  vault_role_id:
+    type: string
+  vault_secret_id:
+    type: string
+  vault_url:
+    type: string
+  team_id:
+    type: string
+  environment_tag:
+    type: string
+  role_tag:
+    type: string
+  stack_branch:
+    type: string
+  worker_version:
+    type: string
+  debug_mode:
+    type: string
+
+resources:
+    server:
+      type: OS::Nova::Server
+      properties:
+        block_device_mapping_v2:
+          - device_name: vda
+            delete_on_termination: true
+            image: { get_param: image_id}
+            volume_size: { get_param: system_disk_size }
+          - device_name: vdb
+            boot_index: -1
+            delete_on_termination: true
+            volume_id: { get_resource: data_volume }
+        flavor: { get_param: flavor }
+        key_name: { get_param: key_name }
+        # Unable to make it work on FE, had API not found (HTTP 404) error
+        # tags:
+        #   - list_join: ['=', [ {get_param: role_tag}, 'role']]
+        #   - list_join: ['=', [ {get_param: project_tag}, 'project']]
+        #   - list_join: ['=', [ {get_param: environment_tag}, 'env']]
+        #   - list_join: ['=', [ {get_param: customer_tag}, 'customer']]
+        networks:
+           - network: { get_param: network_id }
+        security_groups:
+           - { get_param: security_group_id }
+        user_data_format: "RAW"
+        user_data:
+          str_replace:
+            template: |
+              #!/bin/bash
+              set -xe
+
+              export LOG_FILE="/var/log/user-data.log"
+              exec &> >(tee -a ${LOG_FILE})
+
+              export PROJECT="%PROJECT%"
+              export CUSTOMER="%CUSTOMER%"
+              export ENV="%ENV%"
+              export ROLE="%ROLE%"
+              export SCHEDULER_API_ADDRESS="%SCHEDULER_API_ADDRESS%"
+              export SCHEDULER_HOST="%SCHEDULER_HOST%"
+              export SCHEDULER_PORT="%SCHEDULER_PORT%"
+              export TSA_PUBLIC_KEY="%TSA_PUBLIC_KEY%"
+              export TEAM_ID="%TEAM_ID%"
+              export STACK_BRANCH="%STACK_BRANCH%"
+              export VERSION="%VERSION%"
+              export DEBUG="%DEBUG%"
+              export VAULT_URL="%VAULT_URL%"
+              export VAULT_SECRET_ID="%VAULT_SECRET_ID%"
+              export VAULT_ROLE_ID="%VAULT_ROLE_ID%"
+
+              # As those are not autoscaling instances (because Flexible engine does not support templating in user_data)
+              # for autoscaling groups. We decided to keep instances running
+              touch /tmp/keeprunning
+
+              # Run the startup installation script.
+              # The $RANDOM variable is here used to avoid remote network caching.
+              curl -sSL "https://raw.githubusercontent.com/cycloid-community-catalog/stack-external-worker/${STACK_BRANCH}/extra/startup.sh?${RANDOM}" | bash -s flexible-engine
+
+            params:
+              "%CUSTOMER%": { get_param: customer_tag }
+              "%PROJECT%": { get_param: project_tag }
+              "%ENV%": { get_param: environment_tag }
+              "%ROLE%": { get_param: role_tag }
+              "%SCHEDULER_API_ADDRESS%": { get_param: scheduler_api_address }
+              "%SCHEDULER_HOST%": { get_param: scheduler_host }
+              "%SCHEDULER_PORT%": { get_param: scheduler_port }
+              "%TSA_PUBLIC_KEY%": { get_param: tsa_public_key }
+              # "%WORKER_KEY%": { get_param: worker_key }
+              "%TEAM_ID%": { get_param: team_id }
+              "%STACK_BRANCH%": { get_param: stack_branch }
+              "%VERSION%": { get_param: worker_version }
+              "%DEBUG%": { get_param: debug_mode }
+              "%VAULT_ROLE_ID%": { get_param: vault_role_id }
+              "%VAULT_SECRET_ID%": { get_param: vault_secret_id }
+              "%VAULT_URL%": { get_param: vault_url }
+
+    data_volume:
+      type: OS::Cinder::Volume
+      properties:
+        size: { get_param: worker_disk_size}

--- a/extra/flexible-engine/main.yaml
+++ b/extra/flexible-engine/main.yaml
@@ -1,0 +1,139 @@
+heat_template_version: 2016-04-08
+description: Create Cycloid workers
+parameters:
+  project_tag:
+    type: string
+    default: cycloid-worker
+    description: Give a name for this project
+  customer_tag:
+    type: string
+    default: cycloid
+    description: Name of the Cycloid Organization, used as customer variable name
+  flavor:
+    type: string
+    default: s3.large.2
+    description: Compute engine flavor for the Worker
+  image_id:
+    type: string
+    default: 446c5e5f-0987-4a99-9cfa-a3b2f5d64313
+    description: ID of the Operating system image to use for the Worker
+  key_name:
+    type: string
+    default: Cycloid
+    description: The SSH Key Pair to allow SSH access to the instances
+  number_of_workers:
+    type: number
+    default: 1
+    description: Number of Cycloid CI workers.
+  system_disk_size:
+    type: number
+    default: 140
+    description: Size of the disk for Cycloid worker operating system
+  worker_disk_size:
+    type: number
+    default: 150
+    description: Size of the disk volume for Cycloid CI worker
+  network_id:
+    type: string
+    description: Network ID to use in your Virtual Private Cloud (VPC)
+  vpc_id:
+    type: string
+    description: VpcId of your existing Virtual Private Cloud (VPC)
+  ssh_security_group:
+    type: string
+    description: Instances from this security group will be allowed to connect using SSH on Cycloid CI workers
+  scheduler_api_address:
+    type: string
+    default: https://scheduler.cycloid.io
+    description: Cycloid CI scheduler http api address
+  scheduler_host:
+    type: string
+    default: scheduler.cycloid.io
+    description: Cycloid CI scheduler address
+  scheduler_port:
+    type: string
+    default: 32223
+    description: Cycloid CI scheduler port
+  tsa_public_key:
+    type: string
+    default: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC+To6R1hDAO00Xrt8q5Md38J9dh+aMIbV2GTqQkFcKwVAB6czbPPcitPWZ7y3Bw1dKMC8R7DGRAt01yWlkYo/voRp5prqKMc/uzkObhHNy42eJgZlStKU1IMw/fx0Rx+6Y3NClCCOecx415dkAH+PFudKosq4pFB9KjfOp3tMHqirMSF7dsbM3910gcPBL2NFHkOZ4cNfeSztXEg9wy4SExX3CHiUyLiShpwXa+C2f6IPdOJt+9ueXQIL0hcMmd12PRL5UU6/e5U5kldM4EWiJoohVbfoA1CRFF9QwJt6H3IiZPmd3sWqIVVy6Vssn5okjYLRwCwEd8+wd8tI6OnNb"
+    description: Cycloid CI tsa public key of the SaaS platform
+  vault_role_id:
+    type: string
+    description: Cycloid credentials/Vault role ID
+  vault_secret_id:
+    type: string
+    description: Cycloid credentials/Vault secret ID
+  vault_url:
+    type: string
+    default: https://vault.cycloid.io
+    description: URL of Cycloid credentials/Vault service
+  team_id:
+    type: string
+    description: Cycloid CI team ID
+  environment_tag:
+    type: string
+    default: prod
+    description: Name of the project's environment
+  role_tag:
+    type: string
+    default: workers
+    description: Name for the role tag
+  stack_branch:
+    type: string
+    default: master
+    description: Branch of the external-worker stack to use
+  worker_version:
+    type: string
+    default: " "
+    description: Force a specific worker version. Default it will use the version provided by the scheduler API.
+  debug_mode:
+    type: string
+    default: "false"
+    description: Enable of disable debug mode.
+
+resources:
+  cycloid-workers-sg:
+    type: OS::Neutron::SecurityGroup
+    properties:
+      description: Cycloid worker security group. Allowing SSH from ssh_security_group
+      name: allow SSH traffic from ssh_security_group
+      rules:
+        - direction: ingress
+          remote_mode: remote_group_id
+          remote_group_id:  { get_param: ssh_security_group }
+          port_range_min: 22
+          port_range_max: 22
+          protocol: tcp
+        - direction: egress
+          remote_ip_prefix: 0.0.0.0/0
+
+  cycloid-workers:
+    type: OS::Heat::ResourceGroup
+    properties:
+      count: { get_param: number_of_workers }
+      resource_def:
+        type: flexible-engine-worker.yaml
+        properties:
+            image_id: { get_param: image_id }
+            key_name: { get_param: key_name }
+            system_disk_size: { get_param: system_disk_size }
+            worker_disk_size: { get_param: worker_disk_size }
+            flavor: { get_param: flavor }
+            project_tag: { get_param: project_tag }
+            environment_tag: { get_param: environment_tag }
+            role_tag: { get_param: role_tag }
+            customer_tag: { get_param: customer_tag }
+            scheduler_api_address: { get_param: scheduler_api_address }
+            scheduler_host: { get_param: scheduler_host }
+            scheduler_port: { get_param: scheduler_port }
+            tsa_public_key: { get_param: tsa_public_key }
+            team_id: { get_param: team_id }
+            stack_branch: { get_param: stack_branch }
+            worker_version: { get_param: worker_version }
+            debug_mode: { get_param: debug_mode }
+            vault_role_id: { get_param: vault_role_id }
+            vault_secret_id: { get_param: vault_secret_id }
+            vault_url: { get_param: vault_url }
+            network_id: { get_param: network_id }
+            security_group_id: { get_resource: cycloid-workers-sg }


### PR DESCRIPTION
extra: implement flexible engine external worker script based on HEAT

Because of a limitation on parameter length of 2048 char max, we switched the WORKER_KEY to new vault approle login to get this key.

So each time a worker will start, it will do a request to vault to get the worker key from it