### PR TITLE
extra/startup: install gnupg

### DIFF
--- a/extra/startup.sh
+++ b/extra/startup.sh
@@ -193,7 +193,7 @@ _() {
     timeout 300 bash -c "while pgrep apt > /dev/null; do sleep 1; done"
 
     apt-get update
-    apt-get install -yqq --no-install-recommends libssl-dev libffi-dev python3-dev python3-setuptools python3-pip git curl jq cargo
+    apt-get install -yqq --no-install-recommends libssl-dev libffi-dev python3-dev python3-setuptools python3-pip git curl jq cargo gnupg2
 
     cd /opt/
     git clone -b ${STACK_BRANCH} https://github.com/cycloid-community-catalog/stack-external-worker


### PR DESCRIPTION
report script is using gpg.
Install gnupg as soon as possible to get report eve if it fail before
ansible playbook.