### PR TITLE
ansible: remove fluentd

### DIFF
--- a/ansible/external-worker.yml
+++ b/ansible/external-worker.yml
@@ -151,12 +151,6 @@
       tags:
         - concourse
 
-    - role: cycloid.fluentd
-      ignore_errors: true
-      tags:
-        - fluentd
-        - runatboot
-
   tasks:
     # jq used by user-data to send cloudformation signal
     - name: Install jq for user-data signal

--- a/ansible/molecule/default/tests/test_default.py
+++ b/ansible/molecule/default/tests/test_default.py
@@ -22,11 +22,9 @@ def test_mount_point(host):
 
 
 def test_services_running(host):
-    fluentd = host.process.filter(user='root', comm='fluentd')
     telegraf = host.process.filter(user='telegraf', comm='telegraf')
     concourse = host.process.filter(user='root', comm='concourse')
 
-    assert len(fluentd) >= 1
     assert len(telegraf) >= 1
     assert len(concourse) >= 1
 

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -18,11 +18,6 @@
   name: cycloid.systemd
   scm: git
 
-- src: https://github.com/cycloidio/ansible-fluentd
-  version: master
-  name: cycloid.fluentd
-  scm: git
-
 - src: https://github.com/nickhammond/ansible-logrotate
   version: master
   name: nickhammond.ansible-logrotate


### PR DESCRIPTION
Most of the time we do not need worker logs and not centralized logs are
configured.
fluentd takes ~1min to install when worker start. Removing it will
improve the boot time.