### PR TITLE
scw: fix broken scaleway packer build

### DIFF
--- a/ansible/packer/scw.json
+++ b/ansible/packer/scw.json
@@ -26,7 +26,7 @@
       "project_id": "{{user `scw_project`}}",
       "access_key": "{{user `scw_access_key`}}",
       "secret_key": "{{user `scw_secret_key`}}",
-      "image": "cc9188b3-3938-47d7-b091-c9ecad1fe507",
+      "image": "debian_buster",
       "image_name": "{{user `project`}}_{{user `role`}}_{{user `env`}}_{{timestamp}}",
       "snapshot_name": "{{user `project`}}_{{user `role`}}_{{user `env`}}_{{timestamp}}",
       "remove_volume": true,

--- a/ansible/packer/scw.json
+++ b/ansible/packer/scw.json
@@ -1,8 +1,9 @@
 {
   "variables": {
-    "scw_region": "{{env `SCW_REGION`}}",
-    "scw_organization": "{{env `SCALEWAY_ORGANIZATION`}}",
-    "scw_api_token": "{{env `SCALEWAY_API_TOKEN`}}",
+    "scw_zone": "{{env `SCW_ZONE`}}",
+    "scw_project": "{{env `SCALEWAY_PROJECT`}}",
+    "scw_access_key": "{{env `SCALEWAY_ACCESS_KEY`}}",
+    "scw_secret_key": "{{env `SCALEWAY_SECRET_KEY`}}",
     "exposed_team": "{{env `BUILD_TEAM_NAME`}}",
     "customer": "{{env `CUSTOMER`}}",
     "project": "{{env `PROJECT`}}",
@@ -21,9 +22,10 @@
   "builders": [
     {
       "type": "scaleway",
-      "region": "{{user `scw_region`}}",
-      "organization_id": "{{user `scw_organization`}}",
-      "api_token": "{{user `scw_api_token`}}",
+      "zone": "{{user `scw_zone`}}",
+      "project_id": "{{user `scw_project`}}",
+      "access_key": "{{user `scw_access_key`}}",
+      "secret_key": "{{user `scw_secret_key`}}",
       "image": "cc9188b3-3938-47d7-b091-c9ecad1fe507",
       "image_name": "{{user `project`}}_{{user `role`}}_{{user `env`}}_{{timestamp}}",
       "snapshot_name": "{{user `project`}}_{{user `role`}}_{{user `env`}}_{{timestamp}}",

--- a/pipeline/pipeline-aws.yml
+++ b/pipeline/pipeline-aws.yml
@@ -5,7 +5,7 @@ shared:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source:
           repository: cycloid/cycloid-toolkit
           tag: latest
@@ -26,7 +26,7 @@ shared:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source:
           repository: cycloid/cycloid-toolkit
           tag: latest
@@ -45,7 +45,7 @@ shared:
   - &merge-stack-and-config
     platform: linux
     image_resource:
-      type: docker-image
+      type: registry-image
       source:
         repository: cycloid/cycloid-toolkit
         tag: latest
@@ -90,13 +90,13 @@ groups:
 
 resource_types:
 - name: terraform
-  type: docker-image
+  type: registry-image
   source:
     repository: ljfranklin/terraform-resource
     tag: ((terraform_version))
 
 - name: packer
-  type: docker-image
+  type: registry-image
   source:
     # repository: snapkitchen/concourse-packer-resource
     repository: cycloid/concourse-packer-resource

--- a/pipeline/pipeline-scw.yml
+++ b/pipeline/pipeline-scw.yml
@@ -7,7 +7,7 @@ shared:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source:
           repository: cycloid/cycloid-toolkit
           tag: latest
@@ -26,7 +26,7 @@ shared:
   - &merge-stack-and-config
     platform: linux
     image_resource:
-      type: docker-image
+      type: registry-image
       source:
         repository: cycloid/cycloid-toolkit
         tag: latest
@@ -75,13 +75,13 @@ groups:
 
 resource_types:
 - name: terraform
-  type: docker-image
+  type: registry-image
   source:
     repository: ljfranklin/terraform-resource
     tag: ((terraform_version))
 
 - name: packer
-  type: docker-image
+  type: registry-image
   source:
     # repository: snapkitchen/concourse-packer-resource
     repository: cycloid/concourse-packer-resource
@@ -201,9 +201,10 @@ jobs:
       params:
         template: merged-stack/packer/scw.json
         vars:
-          scw_region: ((packer_scw_region))
-          scw_organization: ((scw_organization_id))
-          scw_api_token: ((scw_secret_key))
+          scw_zone: ((packer_scw_zone))
+          scw_project: ((scw_project_id))
+          scw_access_key: ((scw_access_key))
+          scw_secret_key: ((scw_secret_key))
           env: ((env))
           project: ((project))
           customer: ((customer))

--- a/pipeline/variables-scw.sample.yml
+++ b/pipeline/variables-scw.sample.yml
@@ -5,16 +5,20 @@
 # Scaleway access to use to run terraform.
 
 #. scw_access_key (required): ((scaleway.access_key))
-#+ Scaleway access key for Terraform. See [here](https://console.scaleway.com/account/organization/credentials).
+#+ Scaleway access key for Terraform. See [here](https://console.scaleway.com/project/credentials).
 scw_access_key: ((scaleway.access_key))
 
-#. scw_organization_id (required): ((scaleway.secret_key))
-#+ Scaleway secret key for Terraform. See [here](https://console.scaleway.com/account/organization/credentials).
-scw_organization_id: ((scaleway.secret_key))
-
 #. scw_secret_key (required): ((scaleway.secret_key))
-#+ Scaleway organization ID for Terraform. See [here](https://console.scaleway.com/account/organization/credentials).
+#+ Scaleway secret key for Terraform. See [here](https://console.scaleway.com/project/credentials).
 scw_secret_key: ((scaleway.secret_key))
+
+#. scw_organization_id (required): ((scaleway.organization_id))
+#+ Scaleway organization ID for Terraform. See [here](https://console.scaleway.com/account/organization/profile).
+scw_organization_id: ((scaleway.organization_id))
+
+#. scw_project_id (required): ((scaleway.project_id))
+#+ Scaleway project ID for Terraform. See [here](https://console.scaleway.com/project/settings)
+scw_project_id: ((scaleway.project_id))
 
 #. scw_default_region (required): fr-par
 #+ Scaleway region to use for Terraform.
@@ -63,9 +67,9 @@ debug_public_key: "ssh-rsa ..."
 #+ Version of ansible used during Packer build to run Ansible playbook
 packer_ansible_version: "2.9.*"
 
-#. packer_scw_region: "par1"
-#+ Packer specific naming for the Scaleway region to use. The image built will only be usable in this region, so make sure it matches the one in `scw_default_region`. 
-packer_scw_region: par1
+#. packer_scw_zone: "fr-par-1"
+#+ Packer specific naming for the Scaleway zone to use. The image built will only be usable in this zone, so make sure it matches the one in `scw_default_region`.
+packer_scw_zone: fr-par-1
 
 #
 # Repos
@@ -116,6 +120,6 @@ config_terraform_path: ($ project $)/terraform/($ environment $)
 #+ terraform version used to execute your code.
 terraform_version: '0.13.5'
 
-#. packer_version (required): '1.6.4'
+#. packer_version (required): '1.8.0'
 #+ packer version used to build the instance image.
-packer_version: '1.6.4'
+packer_version: '1.8.0'


### PR DESCRIPTION
- Bump concourse-packer-resource to version 1.8.0 for Scaleway
- Replace `region`, `organization_id` and `api_token` deprecated Scaleway packer builder parameters
- Use a marketplace image label to refer to the Debian Buster image
- Replace `docker-image` resource type references by the recommended `registry-image` type

The error encountered:
```
1645622406 | global | version          | 1.6.4
1645622406 | global | version-prelease | 
1645622406 | global | version-commit   | f61a8c09a+CHANGES
1645622406 | global | ui | say      | Packer v1.6.4
1645622406 | global | ui | say      | 
1645622406 | global | ui | say      | Your version of Packer is out of date! The latest version
1645622406 | global | ui | say      | is 1.7.10. You can update by downloading from www.packer.io/downloads
1645622407 | global | ui | say      | Warning: Warning when preparing build: "scaleway"
1645622407 | global | ui | say      | 
1645622407 | global | ui | say      | organization_id is deprecated in favor of project_id
1645622407 | global | ui | say      | 
1645622407 | global | ui | say      | Warning: Warning when preparing build: "scaleway"
1645622407 | global | ui | say      | 
1645622407 | global | ui | say      | token is deprecated in favor of secret_key
1645622407 | global | ui | say      | 
1645622407 | global | ui | say      | Warning: Warning when preparing build: "scaleway"
1645622407 | global | ui | say      | 
1645622407 | global | ui | say      | region is deprecated in favor of zone
1645622407 | global | ui | say      | 
1645622407 | global | ui | say      | Warning: Warning when preparing build: "scaleway"
1645622407 | global | ui | say      | 
1645622407 | global | ui | say      | access_key will be required in future versions
1645622407 | global | ui | say      | 
1645622407 | global | ui | say      | 
1645622407 | global | ui | say      | Warning: Warning when preparing build: "scaleway"
1645622407 | global | ui | say      | 
1645622407 | global | ui | say      | organization_id is deprecated in favor of project_id
1645622407 | global | ui | say      | 
1645622407 | global | ui | say      | Warning: Warning when preparing build: "scaleway"
1645622407 | global | ui | say      | 
1645622407 | global | ui | say      | token is deprecated in favor of secret_key
1645622407 | global | ui | say      | 
1645622407 | global | ui | say      | Warning: Warning when preparing build: "scaleway"
1645622407 | global | ui | say      | 
1645622407 | global | ui | say      | region is deprecated in favor of zone
1645622407 | global | ui | say      | 
1645622407 | global | ui | say      | Warning: Warning when preparing build: "scaleway"
1645622407 | global | ui | say      | 
1645622407 | global | ui | say      | access_key will be required in future versions
1645622407 | global | ui | say      | 
1645622407 | global | ui | say      | 
1645622407 | global | ui | say      | ==> scaleway: Prevalidating image name: external-worker_worker_scaleway_1645622407
1645622407 | global | ui | say      | ==> scaleway: Prevalidating snapshot name: external-worker_worker_scaleway_1645622407
1645622407 | global | ui | say      | ==> scaleway: Creating temporary ssh key for server...
1645622409 | global | ui | say      | ==> scaleway: Creating server...
1645622410 | global | ui | say      | ==> scaleway: Waiting for server to become active...
1645622436 | global | ui | say      | ==> scaleway: Using ssh communicator to connect: 163.172.163.9
1645622436 | global | ui | say      | ==> scaleway: Waiting for SSH to become available...
1645622461 | global | ui | say      | ==> scaleway: Connected to SSH!
1645622461 | global | ui | say      | ==> scaleway: Uploading merged-stack/requirements.txt => /tmp/requirements.txt
1645622462 | global | ui | say      | ==> scaleway: Provisioning with shell script: /tmp/packer-shell040152133
1645622462 | global | ui | message  |     scaleway: Waiting for cloudinit to be done... Can take up to 300 sec
1645622466 | global | ui | error    | ==> scaleway: E: Repository 'http://deb.debian.org/debian buster InRelease' changed its 'Suite' value from 'stable' to 'oldstable'
1645622466 | global | ui | error    | ==> scaleway: E: Repository 'http://deb.debian.org/debian buster-updates InRelease' changed its 'Suite' value from 'stable-updates' to 'oldstable-updates'
1645622466 | global | ui | say      | ==> scaleway: Provisioning step had errors: Running the cleanup provisioner, if present...
1645622466 | global | ui | say      | ==> scaleway: Destroying server...
1645622467 | global | ui | error    | Build 'scaleway' errored after 59 seconds 776 milliseconds: Script exited with non-zero exit status: 100.Allowed exit codes are: [0]
1645622467 | global | ui | say      | 
1645622467 | global | ui | say      | ==> Wait completed after 59 seconds 776 milliseconds
1645622467 | global | error-count | 1
1645622467 | global | ui | error    | 
1645622467 | global | ui | error    | ==> Some builds didn't complete successfully and had errors:
1645622467 | scaleway | error | Script exited with non-zero exit status: 100.Allowed exit codes are: [0]
1645622467 | global | ui | error    | --> scaleway: Script exited with non-zero exit status: 100.Allowed exit codes are: [0]
1645622467 | global | ui | say      | 
1645622467 | global | ui | say      | ==> Builds finished but no artifacts were created.
Traceback (most recent call last):
  File "/opt/resource/out", line 27, in 
    do_out()
  File "/opt/resource/out", line 17, in do_out
    lib.concourse.do_out()
  File "/opt/resource/lib/concourse.py", line 165, in do_out
    build_manifest = lib.packer.build(
  File "/opt/resource/lib/packer.py", line 295, in build
    packer_command_result = _packer(
  File "/opt/resource/lib/packer.py", line 197, in _packer
    raise subprocess.CalledProcessError(
subprocess.CalledProcessError: Command '['packer']' returned non-zero exit status 1.
```